### PR TITLE
fix(ci): unblock main by fixing lint error and E2E API startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,16 +274,27 @@ jobs:
       
       - name: Start API (Background)
         run: |
-          dotnet apps/api/bin/Release/net10.0/Hickory.Api.dll &
-          echo $! > api.pid
+          # Run from the API project directory so appsettings.json (and JWT:Secret default) is picked up.
+          cd apps/api
+          dotnet bin/Release/net10.0/Hickory.Api.dll > "$GITHUB_WORKSPACE/api.log" 2>&1 &
+          echo $! > "$GITHUB_WORKSPACE/api.pid"
         env:
           ASPNETCORE_ENVIRONMENT: Development
+          ASPNETCORE_URLS: http://localhost:5000
           ConnectionStrings__DefaultConnection: Host=localhost;Port=5432;Database=hickory;Username=hickory;Password=hickory_dev_password
           ConnectionStrings__Redis: localhost:6379
+          JWT__Secret: ci-test-secret-key-at-least-32-characters-long-for-testing-only
+          JWT__Issuer: hickory-api
+          JWT__Audience: hickory-web
+          EmailIntegration__WebhookSecret: ci-test-webhook-secret
       
       - name: Wait for API
         run: |
-          timeout 60 bash -c 'until curl -f http://localhost:5000/health 2>/dev/null; do sleep 2; done' || exit 1
+          if ! timeout 60 bash -c 'until curl -f http://localhost:5000/health 2>/dev/null; do sleep 2; done'; then
+            echo "API failed to start within 60s. API log:"
+            cat api.log || true
+            exit 1
+          fi
       
       - name: Run E2E Tests
         run: npx nx e2e web-e2e

--- a/apps/web/src/lib/signalr/signalr-service.ts
+++ b/apps/web/src/lib/signalr/signalr-service.ts
@@ -13,6 +13,7 @@ export interface NotificationMessage {
 export type ConnectionState = 'disconnected' | 'connecting' | 'connected' | 'reconnecting';
 
 type ConnectionStateListener = (state: ConnectionState) => void;
+type NotificationCallback = (notification: NotificationMessage) => void;
 
 class SignalRService {
   private connection: signalR.HubConnection | null = null;
@@ -21,7 +22,7 @@ class SignalRService {
   private reconnectDelay = 1000;
   private isReconnecting = false;
   private accessToken: string | null = null;
-  private callbackWrappers = new Map<Function, Function>();
+  private callbackWrappers = new Map<NotificationCallback, NotificationCallback>();
 
   // Reactive connection state
   private _connectionState: ConnectionState = 'disconnected';


### PR DESCRIPTION
## Root cause

Two issues were turning every PR check (including all 30 open Dependabot PRs) red on `main`:

1. **Lint & Format** — `apps/web/src/lib/signalr/signalr-service.ts:24` used the banned `Function` type for the callback wrapper Map. ESLint rule `@typescript-eslint/no-unsafe-function-type` flagged 2 errors and the job exited with code 1.

2. **E2E Tests** — The API was launched from the repo root via `dotnet apps/api/bin/Release/net10.0/Hickory.Api.dll`, so .NET's content root was the repo root and `appsettings.json` (which lives at `apps/api/appsettings.json`) could not be loaded. The app crashed at startup with `System.InvalidOperationException: JWT:Secret not configured`, the wait-for-API step timed out after 60 s and the job failed.

## Fix

- **signalr-service.ts**: introduce `NotificationCallback` type alias and use it as both the key and value type of `callbackWrappers`, removing all `Function` references.
- **ci.yml**: `cd apps/api` before launching the built DLL so `appsettings.json` is on the content root path; also export `JWT__Secret`, `JWT__Issuer`, `JWT__Audience`, `EmailIntegration__WebhookSecret` and `ASPNETCORE_URLS=http://localhost:5000` as CI-only env vars (matching the URL the health probe hits). Redirect the API stdout/stderr to a log file and dump it from the wait step on timeout for faster future debugging.

No production code or runtime behavior changes.

## Test plan

- [x] `npx nx lint web` passes locally (0 errors)
- [x] `npx nx lint cli` passes locally
- [x] `npx nx test web --ci` passes locally (155/155)
- [ ] Full CI (incl. E2E) is green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)