### PR TITLE
fix(ci): restore E2E startup with OSS MassTransit

### DIFF
--- a/apps/api/Hickory.Api.csproj
+++ b/apps/api/Hickory.Api.csproj
@@ -21,8 +21,8 @@
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
     <PackageReference Include="MailKit" Version="4.16.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.3" />
-    <PackageReference Include="MassTransit" Version="9.0.1" />
-    <PackageReference Include="MassTransit.Redis" Version="9.0.1" />
+    <PackageReference Include="MassTransit" Version="8.5.10" />
+    <PackageReference Include="MassTransit.Redis" Version="8.5.10" />
     <PackageReference Include="MediatR" Version="14.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />


### PR DESCRIPTION
## Summary
- replace commercial MassTransit 9.0.1 packages with the compatible OSS 8.5.10 line
- restore API startup in E2E without a MassTransit license

## Verification
- dotnet restore apps/api/Hickory.Api.csproj
- dotnet build apps/api/Hickory.Api.csproj --configuration Release --no-restore
- dotnet build apps/api/Hickory.Api.IntegrationTests/Hickory.Api.IntegrationTests.csproj --configuration Release
- dotnet test apps/api/Hickory.Api.Tests/Hickory.Api.Tests.csproj --configuration Release --no-restore (370 passed)

The local Docker daemon was unavailable, so GitHub Actions is the database-backed E2E verification.